### PR TITLE
Change title to include date rather than volume & issue.

### DIFF
--- a/collection_templates/collections__torch.xml
+++ b/collection_templates/collections__torch.xml
@@ -3,7 +3,7 @@
     <identifier type="issn">2641-4775</identifier>
     <identifier type="filename">torch_vol${volume}-no${number}</identifier>
     <titleInfo supplied="yes">
-        <title>The Torchbearer, volume ${volume}, number ${number}</title>
+        <title>The Torchbearer, ${date_Issued}</title>
     </titleInfo>
     <abstract>
         Torchbearer is a magazine for alumni, faculty, staff, and friends of the University of Tennessee, Knoxville. It reports on the accomplishments of students and graduates, research conducted at the university, and sporting achievements.


### PR DESCRIPTION
### What has changed?

The variable included with the title text has changed. Current issues of this publication no longer print the volume and issue number on the issue, so the date value is being used instead for identification / differentiation among issues. It would be confusing for users to look at records that identify an issue based on a value they can't see on the item itself.

### Testing

Check that the variable names match throughout. Jeremy, let me know if you foresee us not being able to input a volume/issue number in the future for any reason. If this is the case, we can change the file naming convention and remove the two associated variables.

### Interested Parties
@DonRichards @photosbyjeremy 