### PR TITLE
Playbills

### DIFF
--- a/collection_templates/collections__playbills.xml
+++ b/collection_templates/collections__playbills.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
-    <identifier type="local">0012_003049_000872</identifier>
+    <identifier type="local">${adminDB}</identifier>
     <titleInfo>
         <title>${title}</title>
     </titleInfo>
     <originInfo>
-        <dateIssued>Apr 25, 2013</dateIssued>
-        <dateIssued encoding="edtf">2013-04-25</dateIssued>
-        <dateOther encoding="edtf">2012/2013</dateOther>
+        <dateIssued>${date_Issued}</dateIssued>
+        <dateIssued encoding="edtf">${date_Issued_edtf}</dateIssued>
         <place>
             <placeTerm valueURI="http://id.loc.gov/authorities/names/n80003889">University of Tennessee, Knoxville</placeTerm>
         </place>
@@ -20,7 +19,7 @@
         <topic valueURI="http://id.loc.gov/authorities/subjects/sh85134577">Theater programs</topic>
     </subject>
     <subject>
-        <topic valueURI="http://id.loc.gov/authorities/subjects/sh85028396">College theater </topic>
+        <topic valueURI="http://id.loc.gov/authorities/subjects/sh85028396">College theater</topic>
     </subject>
     <physicalDescription>
         <form authority="aat" valueURI="http://vocab.getty.edu/aat/300027216">playbills</form>

--- a/collection_templates/collections__playbills.xml
+++ b/collection_templates/collections__playbills.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <identifier type="local">0012_003049_000872</identifier>
+    <titleInfo>
+        <title>${title}</title>
+    </titleInfo>
+    <originInfo>
+        <dateIssued>Apr 25, 2013</dateIssued>
+        <dateIssued encoding="edtf">2013-04-25</dateIssued>
+        <dateOther encoding="edtf">2012/2013</dateOther>
+        <place>
+            <placeTerm valueURI="http://id.loc.gov/authorities/names/n80003889">University of Tennessee, Knoxville</placeTerm>
+        </place>
+        <publisher>University of Tennessee Theatre Department</publisher>
+    </originInfo>
+    <subject>
+        <topic valueURI="http://id.loc.gov/authorities/subjects/sh85008007">Art in universities and colleges</topic>
+    </subject>
+    <subject>
+        <topic valueURI="http://id.loc.gov/authorities/subjects/sh85134577">Theater programs</topic>
+    </subject>
+    <subject>
+        <topic valueURI="http://id.loc.gov/authorities/subjects/sh85028396">College theater </topic>
+    </subject>
+    <physicalDescription>
+        <form authority="aat" valueURI="http://vocab.getty.edu/aat/300027216">playbills</form>
+        <internetMediaType>image/jpeg</internetMediaType>
+    </physicalDescription>
+    <typeOfResource>text</typeOfResource>
+    <typeOfResource>still image</typeOfResource>
+    <language>
+        <languageTerm type="text" authority="iso639-2b">English</languageTerm>
+    </language>
+    <relatedItem displayLabel="Project" type="host">
+        <titleInfo>
+            <title>
+                University of Tennessee Theatre Playbills Collection
+            </title>
+        </titleInfo>
+    </relatedItem>
+    <relatedItem displayLabel="Collection" type="host">
+        <titleInfo>
+            <title>University of Tennessee Theatre Collection</title>
+        </titleInfo>
+        <identifier>AR.0235</identifier>
+        <location>
+            <url>http://n2t.net/ark:/87290/v81r6npf</url>
+        </location>
+    </relatedItem>
+    <location>
+        <physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">
+            University of Tennessee, Knoxville. Special Collections
+        </physicalLocation>
+    </location>
+    <recordInfo>
+        <recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+    </recordInfo>
+    <accessCondition type="use and reproduction" xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>

--- a/collection_templates/collections__playbills.yml
+++ b/collection_templates/collections__playbills.yml
@@ -1,0 +1,4 @@
+adminDB: "0012_003049_XXXXXX" # Replace "X" with appropriate adminDB values.
+title: "Title" # Replace with title in title case.
+date_Issued: "Month Day, YYYY" # Replace with date values (e.g. September 21, 2019)
+date_Issued_edtf: "YYYY-MM-DD" # Replace letters with a four-digit year and a two-digit number for month and day (e.g. 2019-09-21)


### PR DESCRIPTION
### What's Changed?

An XML template and a YML file for the playbills collection (found here - [https://digital.lib.utk.edu/collections/islandora/object/collections%3Aplaybills](https://digital.lib.utk.edu/collections/islandora/object/collections%3Aplaybills)) has been added to the repository.

### Testing

Check and see if this works with the existing code and that variables are consistent. 

### Comments

This collection is different from the other continuing publications in that we have adminDB values for these items. As the current records have adminDBs, I am assuming the new records will also be assigned these values. @Loutou , please comment here for all of us on any issues you might foresee with assigning adminDBs for this collection. I am unsure how the workflow will go (Jeremy inputs a value for adminDB and Paul periodically adds these to the database? Perhaps Special Collections / Alesha will be responsible for the addition of the values to the database?)

Note also that name values (for the roles of Stage director, production company, playwright, etc.) and abstracts will need to be added at a later point for these metadata records to be complete and match the granularity of existing records. We will plan to do this on an annual basis (likely right before a DPLA ingest).

### Interested Parties

@photosbyjeremy @DonRichards @Loutou