### PR TITLE
Make naming more consistent across templates.

### DIFF
--- a/collection_templates/collections__alumnus.xml
+++ b/collection_templates/collections__alumnus.xml
@@ -12,7 +12,7 @@
     </abstract>
     <originInfo>
         <dateIssued>${year}</dateIssued>
-        <dateIssued encoding="edtf" keyDate="yes">${dateIssued_edtf}</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">${date_issued_edtf}</dateIssued>
         <publisher>
             University of Tennessee (System). Alumni Association
         </publisher>

--- a/collection_templates/collections__alumnus.yml
+++ b/collection_templates/collections__alumnus.yml
@@ -2,5 +2,5 @@ year: "YYYY" # Replace "X" a four-digit year
 volume: "XX" # Replace "X" with the volume number
 issue: "X" # Replace "X" with the issue number
 season: "season" # Replace season with 'spring', 'summer', 'fall', or 'winter' (note lowercase) as appropriate
-dateIssued_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
+date_issued_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
 # spring = '21', summer= '22', fall= '23', winter= '24'

--- a/collection_templates/collections__catalogs.xml
+++ b/collection_templates/collections__catalogs.xml
@@ -19,7 +19,7 @@
     </name>
     <originInfo>
         <dateOther>${date_academic}</dateOther>
-        <dateIssued keyDate="yes" encoding="edtf">${dateIssued_edtf}</dateIssued>
+        <dateIssued keyDate="yes" encoding="edtf">${date_issued_edtf}</dateIssued>
     </originInfo>
     <physicalDescription>
         <form authority="aat" valueURI="http://vocab.getty.edu/aat/300026614">online catalogs</form>

--- a/collection_templates/collections__catalogs.yml
+++ b/collection_templates/collections__catalogs.yml
@@ -1,5 +1,5 @@
 date_academic: "YYYY-YYYY" # Replace Xs with two four-digit years showing the years spanned by the catalog
 student_type: "x" # Replace "x" with "g" for graduate or "u" for undergraduate (lowercase)
 catalog_type: "X catalog" # Replace "X" with "Graduate" or "Undergraduate"
-dateIssued_edtf: "YYYY" # Replace Xs with the first year date associated with the publication
+date_issued_edtf: "YYYY" # Replace Xs with the first year date associated with the publication
 # e.g. if date_academic is 2017-2018, dateIssued_edtf is 2017

--- a/collection_templates/collections__commencements.xml
+++ b/collection_templates/collections__commencements.xml
@@ -11,7 +11,7 @@
     </abstract>
     <originInfo>
         <dateCreated>${year}</dateCreated>
-        <dateCreated encoding="edtf" keyDate="yes">${dateCreated_edtf}</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes">${date_created_edtf}</dateCreated>
         <publisher>University of Tennessee, Knoxville</publisher>
     </originInfo>
     <physicalDescription>

--- a/collection_templates/collections__commencements.yml
+++ b/collection_templates/collections__commencements.yml
@@ -1,4 +1,4 @@
 year: "YYYY" # Replace "X" a four-digit year
 season: "season" # Replace season with 'spring', 'summer', 'fall', or 'winter' (note lowercase) as appropriate
-dateCreated_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
+date_created_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
 # spring = '21', summer= '22', fall= '23', winter= '24'

--- a/collection_templates/collections__phoenix.xml
+++ b/collection_templates/collections__phoenix.xml
@@ -19,7 +19,7 @@
     </physicalDescription>
     <originInfo>
         <dateIssued>${year}</dateIssued>
-        <dateIssued encoding="edtf">${dateIssued_edtf}</dateIssued>
+        <dateIssued encoding="edtf">${date_issued_edtf}</dateIssued>
         <place>
             <placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
         </place>

--- a/collection_templates/collections__phoenix.yml
+++ b/collection_templates/collections__phoenix.yml
@@ -1,4 +1,4 @@
 year: "YYYY" # Replace "X" a four-digit year
 season: "season" # Replace season with 'spring', 'summer', 'fall', or 'winter' (note lowercase) as appropriate
-dateIssued_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
+date_issued_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
 # spring = '21', summer= '22', fall= '23', winter= '24'

--- a/collection_templates/collections__playbills.xml
+++ b/collection_templates/collections__playbills.xml
@@ -5,8 +5,8 @@
         <title>${title}</title>
     </titleInfo>
     <originInfo>
-        <dateIssued>${date_Issued}</dateIssued>
-        <dateIssued encoding="edtf">${date_Issued_edtf}</dateIssued>
+        <dateIssued>${date_issued}</dateIssued>
+        <dateIssued encoding="edtf">${date_issued_edtf}</dateIssued>
         <place>
             <placeTerm valueURI="http://id.loc.gov/authorities/names/n80003889">University of Tennessee, Knoxville</placeTerm>
         </place>

--- a/collection_templates/collections__playbills.yml
+++ b/collection_templates/collections__playbills.yml
@@ -1,4 +1,4 @@
 adminDB: "0012_003049_XXXXXX" # Replace "X" with appropriate adminDB values.
 title: "Title" # Replace with title in title case.
-date_Issued: "Month Day, YYYY" # Replace with date values (e.g. September 21, 2019)
-date_Issued_edtf: "YYYY-MM-DD" # Replace letters with a four-digit year and a two-digit number for month and day (e.g. 2019-09-21)
+date_issued: "Month Day, YYYY" # Replace with date values (e.g. September 21, 2019)
+date_issued_edtf: "YYYY-MM-DD" # Replace letters with a four-digit year and a two-digit number for month and day (e.g. 2019-09-21)

--- a/collection_templates/collections__torch.xml
+++ b/collection_templates/collections__torch.xml
@@ -3,7 +3,7 @@
     <identifier type="issn">2641-4775</identifier>
     <identifier type="filename">torch_vol${volume}-no${number}</identifier>
     <titleInfo supplied="yes">
-        <title>The Torchbearer, ${date_Issued}</title>
+        <title>The Torchbearer, ${date_issued}</title>
     </titleInfo>
     <abstract>
         Torchbearer is a magazine for alumni, faculty, staff, and friends of the University of Tennessee, Knoxville. It reports on the accomplishments of students and graduates, research conducted at the university, and sporting achievements.
@@ -15,8 +15,8 @@
         </role>
     </name>
     <originInfo>
-        <dateIssued>${date_Issued}</dateIssued>
-        <dateIssued encoding="edtf" keyDate="yes">${date_Issued_edtf}</dateIssued>
+        <dateIssued>${date_issued}</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">${date_issued_edtf}</dateIssued>
         <publisher>University of Tennessee, Knoxville. Office of Communications and Marketing</publisher>
         <publisher>University of Tennessee, Knoxville. Office of Alumni Affairs</publisher>
         <place>

--- a/collection_templates/collections__torch.yml
+++ b/collection_templates/collections__torch.yml
@@ -1,5 +1,5 @@
 volume: "XX" # Replace XX with the volume number
 number: "X" # Replace X with the number or issue number
-date_Issued: "Season YYYY" # Replace with the season fully written out and the four-digit year, e.g. Spring 2019
-date_Issued_edtf: "YYYY-MM" # Replace letters with a four-digit year and a two-digit number for season 
+date_issued: "Season YYYY" # Replace with the season fully written out and the four-digit year, e.g. Spring 2019
+date_issued_edtf: "YYYY-MM" # Replace letters with a four-digit year and a two-digit number for season 
 #(spring = 21, summer = 22, fall = 23, winter = 24), e.g. 2019-21 for Spring 2019

--- a/collection_templates/gsmrc__smhc.xml
+++ b/collection_templates/gsmrc__smhc.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
-    <identifier type="filename">HikingClubHandbook_${mods_dateIssued}</identifier>
+    <identifier type="filename">HikingClubHandbook_${year}</identifier>
     <titleInfo>
-        <title>${mods_title}</title>
+        <title>${title}</title>
     </titleInfo>
     <titleInfo type="alternative">
-        <title>Handbook ${mods_dateIssued}: Smoky Mountains Hiking Club</title>
+        <title>Handbook ${year}: Smoky Mountains Hiking Club</title>
     </titleInfo>
     <abstract>Annual handbook which outlines the Smoky Mountains Hiking Club's schedule of hikes and social events for the year. Includes membership roster and lists committee members.</abstract>
     <originInfo>
-        <dateIssued>${mods_dateIssued}</dateIssued>
-        <dateIssued encoding="edtf" keyDate="yes">${mods_dateIssued}</dateIssued>
+        <dateIssued>${year}</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">${year}</dateIssued>
     </originInfo>
     <physicalDescription>
         <extent>6 x 4 inches</extent>

--- a/collection_templates/gsmrc__smhc.yml
+++ b/collection_templates/gsmrc__smhc.yml
@@ -1,2 +1,2 @@
-mods_title: "YYYY Handbook of the Smoky Mountains Hiking Club" # Replace 'YYYY' with four-digit year
-mods_dateIssued: "YYYY" # Replace 'YYYY' with four-digit year
+title: "YYYY Handbook of the Smoky Mountains Hiking Club" # Replace 'YYYY' with four-digit year
+year: "YYYY" # Replace 'YYYY' with four-digit year


### PR DESCRIPTION
## Reason for Pull Request

The template files were originally created with very little attention given to consistency in variable names across collections. This PR addresses this by streamlining the variable names, given feedback from @photosbyjeremy This will make it easier for input to be done consistently.

## Testing

Do the variable names match across XML and YML files for the same collection?

## Interested Parties

@photosbyjeremy @DonRichards 