### PR TITLE
Remove volume and issue numbers from alumnus metadata

### DIFF
--- a/collection_templates/collections__alumnus.xml
+++ b/collection_templates/collections__alumnus.xml
@@ -4,7 +4,7 @@
     <identifier type="filename">alum_${year}${season}</identifier>
     <titleInfo supplied="yes">
         <title>
-            The Tennessee Alumnus, volume ${volume}, issue ${issue}, ${year} ${season}
+            The Tennessee Alumnus, ${year} ${season}
         </title>
     </titleInfo>
     <abstract>

--- a/collection_templates/collections__alumnus.yml
+++ b/collection_templates/collections__alumnus.yml
@@ -1,6 +1,4 @@
 year: "YYYY" # Replace "X" a four-digit year
-volume: "XX" # Replace "X" with the volume number
-issue: "X" # Replace "X" with the issue number
 season: "season" # Replace season with 'spring', 'summer', 'fall', or 'winter' (note lowercase) as appropriate
 date_issued_edtf: "YYYY-SS" # Replace letters with a four-digit year and a two-digit number for season
 # spring = '21', summer= '22', fall= '23', winter= '24'


### PR DESCRIPTION
Due to inconsistencies in how the serial itself applies volume and issue numbers, they are being removed from the automated Alumnus ingest process. 