### PR TITLE
Add files for men's and women's basketball

### DIFF
--- a/collection_templates/collections_menbball.xml
+++ b/collection_templates/collections_menbball.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <identifier type="local">${identifier}</identifier>
+    <titleInfo supplied="yes">
+        <title>Tennessee Volunteers basketball media guide, ${athletic_season}</title>
+    </titleInfo>
+    <originInfo>
+        <dateIssued>${year}</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">${year}</dateIssued>
+        <publisher>University of Tennessee (Knoxville campus). Department of Athletics</publisher>
+        <place>
+            <placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+        </place>
+    </originInfo>
+    <abstract>Tennessee Volunteers basketball program from ${year}.</abstract>
+    <physicalDescription>
+        <form authority="aat" valueURI="http://vocab.getty.edu/aat/300311670">booklets</form>
+        <extent>${extent}</extent>
+    </physicalDescription>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85012111">
+        <topic>Basketball</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85012123">
+        <topic>Basketball players</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85028338">
+        <topic>College sports</topic>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n80003887">
+        <name>
+            <namePart>University of Tennessee (Knoxville campus)</namePart>
+        </name>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n90646693">
+        <name>
+            <namePart>Tennessee Volunteers (Basketball team)</namePart>
+        </name>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n79109786">
+        <geographic>Knoxville (Tenn.)</geographic>
+        <cartographics>
+            <coordinates>35.96064, -83.92074</coordinates>
+        </cartographics>
+    </subject>
+    <typeOfResource>text</typeOfResource>
+    <classification authority="lcc">LD5296.A6</classification>
+    <relatedItem displayLabel="Project" type="host">
+        <titleInfo>
+            <title>University of Tennessee Volunteers Basketball Media Guides</title>
+        </titleInfo>
+    </relatedItem>
+    <location>
+        <physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">University of Tennessee, Knoxville. Special Collections</physicalLocation>
+    </location>
+    <recordInfo>
+        <recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+    </recordInfo>
+    <accessCondition type="use and reproduction"
+        xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>

--- a/collection_templates/collections_menbball.yml
+++ b/collection_templates/collections_menbball.yml
@@ -1,0 +1,5 @@
+identifier: "vols-basketball_YYYY" # Input identifier. Typically simply replace "YYYY" with the four digit year, 
+# but additions need to be made for postseason, preview, and outlook guides (e.g. vols-basketball_2001_postseason, vols-basketball_1997_outlook).
+year: "YYYY" # Replace "X" a four-digit publication year (the first of the two years for the listed season)
+athletic_season: "20XX-20XX" # Replace XX so that both years the athletic season took place in are represented (2020-2021)
+extent: "XX pages" # Replace "XX" with the total number of digital files/scans as the pages

--- a/collection_templates/collections_menbball.yml
+++ b/collection_templates/collections_menbball.yml
@@ -1,5 +1,5 @@
 identifier: "vols-basketball_YYYY" # Input identifier. Typically simply replace "YYYY" with the four digit year, 
-# but additions need to be made for postseason, preview, and outlook guides (e.g. vols-basketball_2001_postseason, vols-basketball_1997_outlook).
+# but additions need to be made for postseason, preview, and outlook guides (e.g. vols-basketball_2001-postseason, vols-basketball_1997-outlook).
 year: "YYYY" # Replace "X" a four-digit publication year (the first of the two years for the listed season)
 athletic_season: "20XX-20XX" # Replace XX so that both years the athletic season took place in are represented (2020-2021)
 extent: "XX pages" # Replace "XX" with the total number of digital files/scans as the pages

--- a/collection_templates/collections_womenbball.xml
+++ b/collection_templates/collections_womenbball.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <identifier type="local">lady-vols-basketball_${year}</identifier>
+    <titleInfo supplied="yes">
+        <title>Tennessee Lady Volunteers basketball media guide, ${athletic_season}</title>
+    </titleInfo>
+    <originInfo>
+        <dateIssued>${year}</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">${year}</dateIssued>
+        <publisher>University of Tennessee, Knoxville. Department of Athletics</publisher>
+        <place>
+            <placeTerm valueURI="http://id.loc.gov/authorities/names/n79109786">Knoxville (Tenn.)</placeTerm>
+        </place>
+    </originInfo>
+    <abstract>Lady Volunteers basketball program from ${year}.</abstract>
+    <physicalDescription>
+        <form authority="aat" valueURI="http://vocab.getty.edu/aat/300311670">booklets</form>
+        <extent>${extent}</extent>
+    </physicalDescription>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85012111">
+        <topic>Basketball</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh2004010434">
+        <topic>College sports for women</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85028338">
+        <topic>College sports</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85012123">
+        <topic>Basketball players</topic>
+    </subject>
+    <subject authority="lcsh"
+        valueURI="http://id.loc.gov/authorities/subjects/sh85147485">
+        <topic>Women basketball players</topic>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n80003889">
+        <name>
+            <namePart>University of Tennessee, Knoxville</namePart>
+        </name>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n88072776">
+        <name>
+            <namePart>Lady Volunteers (Basketball team)</namePart>
+        </name>
+    </subject>
+    <subject authority="naf"
+        valueURI="http://id.loc.gov/authorities/names/n79109786">
+        <geographic>Knoxville (Tenn.)</geographic>
+        <cartographics>
+            <coordinates>35.96064, -83.92074</coordinates>
+        </cartographics>
+    </subject>
+    <typeOfResource>text</typeOfResource>
+    <classification authority="lcc">LD5296.A7</classification>
+    <relatedItem displayLabel="Project" type="host">
+        <titleInfo>
+            <title>University of Tennessee Lady Volunteers Basketball Media Guides</title>
+        </titleInfo>
+    </relatedItem>
+    <location>
+        <physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">University of Tennessee, Knoxville. Special Collections</physicalLocation>
+    </location>
+    <recordInfo>
+        <recordContentSource valueURI="http://id.loc.gov/authorities/names/n87808088">University of Tennessee, Knoxville. Libraries</recordContentSource>
+    </recordInfo>
+    <accessCondition type="use and reproduction"
+        xlink:href="http://rightsstatements.org/vocab/InC/1.0/">In Copyright</accessCondition>
+</mods>

--- a/collection_templates/collections_womenbball.xml
+++ b/collection_templates/collections_womenbball.xml
@@ -4,7 +4,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
-    <identifier type="local">lady-vols-basketball_${year}</identifier>
+    <identifier type="local">${identifier}</identifier>
     <titleInfo supplied="yes">
         <title>Tennessee Lady Volunteers basketball media guide, ${athletic_season}</title>
     </titleInfo>

--- a/collection_templates/collections_womenbball.yml
+++ b/collection_templates/collections_womenbball.yml
@@ -1,0 +1,5 @@
+identifier: "lady-vols-basketball_YYYY" # Input identifier. Typically simply replace "YYYY" with the four digit year, 
+# but additions need to be made for postseason, preview, and outlook guides (e.g. lady-vols-basketball_2001_postseason, lady-vols-basketball_1997_outlook).
+year: "YYYY" # Replace "X" a four-digit publication year (the first of the two years for the listed season)
+athletic_season: "20XX-20XX" # Replace XX so that both years the athletic season took place in are represented (2019-2020)
+extent: "XX pages" # Replace "XX" with the total number of digital files/scans as the pages

--- a/collection_templates/collections_womenbball.yml
+++ b/collection_templates/collections_womenbball.yml
@@ -1,5 +1,5 @@
 identifier: "lady-vols-basketball_YYYY" # Input identifier. Typically simply replace "YYYY" with the four digit year, 
-# but additions need to be made for postseason, preview, and outlook guides (e.g. lady-vols-basketball_2001_postseason, lady-vols-basketball_1997_outlook).
+# but additions need to be made for postseason, preview, and outlook guides (e.g. lady-vols-basketball_2001-postseason, lady-vols-basketball_1997-outlook).
 year: "YYYY" # Replace "X" a four-digit publication year (the first of the two years for the listed season)
 athletic_season: "20XX-20XX" # Replace XX so that both years the athletic season took place in are represented (2019-2020)
 extent: "XX pages" # Replace "XX" with the total number of digital files/scans as the pages


### PR DESCRIPTION
JIRA Issue: [CON-27](https://jirautk.atlassian.net/browse/CON-27)
JIRA Issue: [CON-26](https://jirautk.atlassian.net/browse/CON-26)

### What does this pull request do?

It adds XML templates and associated YML files for the men's and women's basketball collections. The files are used to create minimal metadata for these continuing publications.

### How should this be tested?

* Check and make sure that all of the variable names in the YML file match what's present in the XML file.
* Run the program with test files.

### Additional notes:

These templates have an additional variable of "identifier" that couldn't be simplified out by simply using the "year" variable since we have some media guides that have the same year and need "-postseason", "-outlook", etc. added to make them unique. Please let me know if the comment for creating the identifier could be clearer or if I've left anything out. Also feel free to let me know if any other variable changes would streamline this.

### Interested parties

@DonRichards @jeremydmoore 